### PR TITLE
tweaks the how part 

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
 <div>Then, the <em>style</em> you export from Mapbox Studio is saved as a <strong>JSON file</strong>.</div>
 <div>So when you <em>load</em> your map and <strong>request</strong> tiles, <em>what</em> is being served?</div>
 <div>The <strong>protocol buffers</strong> in the map area and the <em>JSON file</em> that represents the style.</div>
-<div>Then your <strong>browser</strong> puts the two together and <em>renders the image</em>!</div>
+<div>Then <strong>Mapbox servers</strong> instantly combine the two into an image and <em>send it to your browser</em>!</div>
 <div data-bodyclass='mindblown'></div>
 <div>This makes the tiles <strong>way faster</strong>!</div>
 <div>Plus, all of the <em>vector information</em> is still stored in the tile...</div>


### PR DESCRIPTION
the combination of vector source + style --> raster tile (currently) occurs on the backend, on Mapbox servers, rather than on the client side in the browser 
